### PR TITLE
Fixes get(Id) for users plus get-all endpoint

### DIFF
--- a/src/erp/users.erl
+++ b/src/erp/users.erl
@@ -9,7 +9,7 @@ init()               -> ets:new(users, [public, named_table, {keypos, #user.id}]
 populate(Users)      -> ets:insert(users, Users).
 exists(Id)           -> X = ets:member(users, binary_to_list(Id)), io:format("Member: ~p~n",[X]), X.
 get()                -> ets:tab2list(users).
-get(Id)              -> #user{id=Id}.
+get(Id)              -> [U] = ets:lookup(users, binary_to_list(Id)), io:format("User: ~p~n",[U]), U.
 delete(Id)           -> ets:delete(users, binary_to_list(Id)).
 post(#user{} = User) -> ets:insert(users, User);
 post(Data)           -> post(from_json(Data, #user{})).


### PR DESCRIPTION
Hi, great job on synrc*! 

I had to tweak the users.erl file a bit in order to get the data from the ets-table.
Also the cowboy-handler needed a clause to return all users if it was requested.

After this the repo works as advertised.
It might be a good idea to sync the  README.md and the users.erl implementation.
Since you removed the n2o-dependency wf:to_list will not work etc.
Just to make sure the information is the same all over the place.

PS: If you want to "show off" the kvs-integration - maybe one could add a rebar3-shell - pointing
to sys.config with the needed configuration - to make it easier to test.

Kind regards,

Fabian



